### PR TITLE
fix: Fix NameError on root endpoint

### DIFF
--- a/webkeys.py
+++ b/webkeys.py
@@ -789,19 +789,9 @@ def _make_report_files(data: Dict[str, Any]) -> Tuple[Optional[str], Optional[st
     return html_path, md_path
 
 
-@app.route("/", methods=["GET", "POST"])
+@app.route("/", methods=["GET"])
 def index():
-    if request.method == "POST":
-        domain = request.form.get("domain")  # ورودی از فرم
-        if not domain:
-            return "لطفاً دامنه وارد کنید!", 400
-
-        # اجرای عملیات اصلی (مثلاً اسکن یا تولید گزارش)
-        result = {"domain": domain, "status": "done"}
-
-        return jsonify(result)  # برگردوندن خروجی به صورت JSON
-
-    return render_template("index.html")
+    return render_template_string(INDEX_HTML)
 
 
 def _render_analysis_result(data: Dict[str, Any]) -> str:


### PR DESCRIPTION
The index route was attempting to call `render_template` and `jsonify` without importing them. It also contained dead code for POST requests.

This commit fixes the issue by rewriting the index route to only handle GET requests and correctly use `render_template_string` to render the main page, consistent with the rest of the application.